### PR TITLE
Fix replotting 0% treated as end of sector

### DIFF
--- a/Subspace_Farm_Monitor_Thingy/monitor/monitor.py
+++ b/Subspace_Farm_Monitor_Thingy/monitor/monitor.py
@@ -334,9 +334,9 @@ def parse_log_line(line_plain, curr_farm, reward_count, farm_rewards, farm_recen
        # if c.prove_method[farm]
     
     elif "lotting sector" in line_plain or "lotting complete" in line_plain:
-        c.last_sector_time[farm] = line_timestamp - event_times[farm]
+        if "Replotting sector (0.00%" not in line_plain:
+            c.last_sector_time[farm] = line_timestamp - event_times[farm]
         event_times[farm] = line_timestamp
-        # print('Last sector time:' + str(last_sector_time[farm]))
         trigger = True
 
     elif 'Directory:' in line_plain and c.curr_farm:


### PR DESCRIPTION
This makes Replotting 0% message not change last sector time as if it were finishing, rather than beginning, a sector